### PR TITLE
1 feat로그인회원가입api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+DB_HOST="여러분들이 사용하는 데이터베이스 주소"
+DB_PORT=3306
+DB_USERNAME="데이터베이스 계정"
+DB_PASSWORD="데이터베이스 암호"
+DB_NAME="board"
+DB_SYNC=true
+
+JWT_SECRET_KEY='JWT_SECRET_KEY'
+HASH_TIMES=1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,51 @@
+import Joi from 'joi';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
+
+import { AuthModule } from './auth/auth.module';
+import { User } from './users/entities/user.entity';
+import { UsersModule } from './users/users.module';
+
+const typeOrmModuleOptions = {
+  useFactory: async (
+    configService: ConfigService,
+  ): Promise<TypeOrmModuleOptions> => ({
+    namingStrategy: new SnakeNamingStrategy(),
+    type: "mysql",
+    username: configService.get('DB_USERNAME'),
+    password: configService.get('DB_PASSWORD'),
+    host: configService.get('DB_HOST'),
+    port: configService.get('DB_PORT'),
+    database: configService.get('DB_NAME'),
+    entities: [User],
+    synchronize: configService.get('DB_SYNC'),
+    logging: true,
+  }),
+  inject: [ConfigService],
+}
 
 @Module({
-  imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validationSchema: Joi.object({
+        JWT_SECRET_KEY: Joi.string().required(),
+        DB_USERNAME: Joi.string().required(),
+        DB_PASSWORD: Joi.string().required(),
+        DB_HOST: Joi.string().required(),
+        DB_PORT: Joi.number().required(),
+        DB_NAME: Joi.string().required(),
+        DB_SYNC: Joi.boolean().required(),
+      }),
+    }),
+    TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+    AuthModule,
+    UsersModule,
+  ],
+  controllers: [],
+  providers: [],
 })
 export class AppModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+
+import { JwtStrategy } from './jwt.strategy';
+import { UsersModule } from 'src/users/users.module';
+
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt', session: false }),
+    JwtModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET_KEY'),
+      }),
+      inject: [ConfigService],
+    }),
+    UsersModule,
+  ],
+  providers: [JwtStrategy],
+})
+export class AuthModule {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+
+import { UsersService } from 'src/users/users.service';
+import { NotFoundError } from 'rxjs';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly configService: ConfigService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get('JWT_SECRET_KEY'),
+    });
+  }
+
+  async validate(payload: any) {
+    const user = await this.usersService.findByEmail(payload.email);
+    if(_.isNil(user)) {
+      throw new NotFoundError("해당하는 사용자를 찾을 수 없습니다.")
+    }
+
+    return user;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
+
   await app.listen(3000);
 }
+
 bootstrap();

--- a/src/users/dto/sign-in.dto.ts
+++ b/src/users/dto/sign-in.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class SignInDto {
+  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
+  password: string;
+}

--- a/src/users/dto/sign-up.dto.ts
+++ b/src/users/dto/sign-up.dto.ts
@@ -1,0 +1,19 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class SignUpDto {
+  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
+  password: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호 확인을 입력해주세요.' })
+  passwordConfirm: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '닉네임을 입력해주세요.' })
+  nickname: string;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,0 +1,33 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+import { ROLE } from '../types/userRole.type';
+
+@Index('email', ['email'], { unique: true })
+@Entity({
+  name: 'users',
+})
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', unique: true, nullable: false })
+  email: string;
+
+  @Column({ type: 'varchar', select: false, nullable: false })
+  password: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  nickname: string;
+
+  @Column({ type: 'enum', enum: ROLE, default: ROLE.USER })
+  role: ROLE;
+
+  @Column({ type: 'int', default: 1000000 })
+  point: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/users/types/userRole.type.ts
+++ b/src/users/types/userRole.type.ts
@@ -1,0 +1,4 @@
+export enum ROLE {
+  USER = 'user',
+  ADMIN = 'admin',
+}

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+
+describe('UsersController', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,37 @@
+import { UserInfo } from 'src/utils/userInfo.decorator';
+
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+import { SignUpDto } from './dto/sign-up.dto';
+import { SignInDto } from './dto/sign-in.dto';
+import { User } from './entities/user.entity';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post('sign-up')
+  async register(@Body() signUpDto: SignUpDto) {
+    return await this.usersService.signUp(signUpDto.email, signUpDto.password, signUpDto.passwordConfirm, signUpDto.nickname);
+  }
+
+  @Post('sign-in')
+  async login(@Body() signInDto: SignInDto) {
+    return await this.usersService.signIn(signInDto.email, signInDto.password);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('')
+  async getMyInfo(@UserInfo() user: User) {
+    return await this.usersService.findByEmail(user.email);
+  }
+
+//   // 예매 기록 조회
+//   @UseGuards(AuthGuard('jwt'))
+//   @Get('reservations')
+//   async getMyReservations(@UserInfo() user: User) {
+//     return await this.reservationsService.findByEmail(user.email);
+//   }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { User } from './entities/user.entity';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      useFactory: (config:ConfigService) => ({
+        secret:config.get<string>("JWT_SECRET_KEY"),
+      }),
+      inject: [ConfigService],
+    }),
+    TypeOrmModule.forFeature([User])
+  ],
+  providers: [UsersService],
+  controllers: [UsersController],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,67 @@
+import { compare, hash } from 'bcrypt';
+import _ from 'lodash';
+import { Repository } from 'typeorm';
+
+import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { User } from './entities/user.entity';
+import { ROLE } from './types/userRole.type';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async signUp(email: string, password: string, passwordConfirm: string, nickname: string) {
+    // password = passwordConfirm ?
+    if (password !== passwordConfirm) {
+      throw new ConflictException('비밀번호가 일치하지 않습니다.');
+    }
+
+    const existingUser = await this.findByEmail(email);
+    if (existingUser) {
+      throw new ConflictException(
+        '이미 해당 이메일로 가입된 사용자가 있습니다!',
+      );
+    }
+    // this.configService.get<number>('HASH_TIMES')
+    const hashedPassword = await hash(password, 12);
+    await this.userRepository.save({
+      email,
+      password: hashedPassword,
+      nickname,
+      role: ROLE.USER,
+    });
+
+    return { message: '회원가입에 성공하셨습니다.' };
+  }
+
+  async signIn(email: string, password: string) {
+    const user = await this.userRepository.findOne({
+      select: ['id', 'email', 'password'],
+      where: { email },
+    });
+    if (_.isNil(user)) {
+      throw new UnauthorizedException('이메일을 확인해주세요.');
+    }
+
+    if (!(await compare(password, user.password))) {
+      throw new UnauthorizedException('비밀번호를 확인해주세요.');
+    }
+
+    const payload = { email, sub: user.id, role: user.role };
+    return {
+      access_token: this.jwtService.sign(payload),
+    };
+  }
+
+  async findByEmail(email: string) {
+    return await this.userRepository.findOneBy({ email });
+  }
+}

--- a/src/utils/userInfo.decorator.ts
+++ b/src/utils/userInfo.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+// JWT 인증이 완료된 유저에 한해서 유저 데이터를 갖고오게 하는 데코레이터
+export const UserInfo = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user ? request.user : null;
+  },
+);


### PR DESCRIPTION
1. 회원가입 API **url : /users/sign-up**
 - 이메일
 - 비밀번호
 - 비밀번호 확인
 - 닉네임
 - return은 "회원가입에 성공하셨습니다." 다른 정보 ㄴㄴ

- [x] JWT
- [x] default point는 100만
- [x] default role은 User

2. 로그인 API **url : /users/sign-in**
- 이메일
- 비밀번호
- return accesstoken

-> URL 수정됨!