### PR TITLE
7 feat예매예매기록조회api

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { User } from "./users/entities/user.entity";
 import { Show } from "./shows/entities/show.entity";
 import { ShowDetail } from "./shows/entities/show-detail.entity";
 import { ReservationsModule } from './reservations/reservations.module';
+import { Reservation } from "./reservations/entities/reservation.entity";
 
 const typeOrmModuleOptions = {
   useFactory: async (configService: ConfigService): Promise<TypeOrmModuleOptions> => ({
@@ -22,7 +23,7 @@ const typeOrmModuleOptions = {
     host: configService.get("DB_HOST"),
     port: configService.get("DB_PORT"),
     database: configService.get("DB_NAME"),
-    entities: [User, Show, ShowDetail],
+    entities: [User, Show, ShowDetail, Reservation],
     synchronize: configService.get("DB_SYNC"),
     logging: true,
   }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.useGlobalPipes(
+    // DTO가 유효성 검사를 자동으로 함
     new ValidationPipe({
       transform: true,
     }),

--- a/src/reservations/dto/create-reservation.dto.ts
+++ b/src/reservations/dto/create-reservation.dto.ts
@@ -1,0 +1,6 @@
+import { IsInt } from "class-validator";
+
+export class CreateReservationDto {
+  @IsInt()
+  showDetailId: number;
+}

--- a/src/reservations/entities/reservation.entity.ts
+++ b/src/reservations/entities/reservation.entity.ts
@@ -1,0 +1,51 @@
+import { ShowDetail } from "src/shows/entities/show-detail.entity";
+import { User } from "src/users/entities/user.entity";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { RESERVATION_STATUS } from "../types/reservation-status.type";
+
+@Entity({
+  name: "reservations",
+})
+export class Reservation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  // RESERVED, CANCELLED, COMPLETED
+  @Column({
+    type: "enum",
+    enum: RESERVATION_STATUS,
+    default: RESERVATION_STATUS.RESERVED,
+    nullable: false,
+  })
+  status: RESERVATION_STATUS;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  // userId를 user로 변경
+  @ManyToOne((type) => User, (user) => user.reservations)
+  @JoinColumn({ name: "user_id", referencedColumnName: "id" })
+  user: User;
+
+  @Column({ type: "int", name: "user_id" })
+  user_id: number;
+
+  // showDetailId를 showDetail로 변경
+  @ManyToOne((type) => ShowDetail, (showDetail) => showDetail.reservations)
+  @JoinColumn({ name: "show_detail_id", referencedColumnName: "id" })
+  showDetail: ShowDetail;
+
+  @Column({ type: "int", name: "show_detail_id" })
+  show_detail_id: number;
+}

--- a/src/reservations/reservations.controller.spec.ts
+++ b/src/reservations/reservations.controller.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ReservationsController } from './reservations.controller';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ReservationsController } from "./reservations.controller";
 
-describe('ReservationsController', () => {
+describe("ReservationsController", () => {
   let controller: ReservationsController;
 
   beforeEach(async () => {
@@ -12,7 +12,7 @@ describe('ReservationsController', () => {
     controller = module.get<ReservationsController>(ReservationsController);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
   });
 });

--- a/src/reservations/reservations.controller.ts
+++ b/src/reservations/reservations.controller.ts
@@ -1,4 +1,25 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, Post, Req } from "@nestjs/common";
 
-@Controller('reservations')
-export class ReservationsController {}
+import { AuthGuard } from "@nestjs/passport";
+import { UseGuards } from "@nestjs/common";
+import { ReservationsService } from "./reservations.service";
+import { User } from "src/users/entities/user.entity";
+import { UserInfo } from "src/utils/userInfo.decorator";
+
+@UseGuards(AuthGuard("jwt"))
+@Controller("reservations")
+export class ReservationsController {
+  constructor(private readonly reservationsService: ReservationsService) {}
+
+  @Post(":showDetailId")
+  async createReservation(@Param("showDetailId") showDetailId: number, @UserInfo() user: User) {
+    const userId = +user.id;
+    return this.reservationsService.createReservation(showDetailId, userId);
+  }
+
+  @Get("")
+  async getReservations(@UserInfo() user: User) {
+    const userId = +user.id;
+    return this.reservationsService.getReservations(userId);
+  }
+}

--- a/src/reservations/reservations.module.ts
+++ b/src/reservations/reservations.module.ts
@@ -1,9 +1,14 @@
-import { Module } from '@nestjs/common';
-import { ReservationsService } from './reservations.service';
-import { ReservationsController } from './reservations.controller';
+import { Module } from "@nestjs/common";
+import { ReservationsService } from "./reservations.service";
+import { ReservationsController } from "./reservations.controller";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Reservation } from "./entities/reservation.entity";
+import { ShowDetail } from "src/shows/entities/show-detail.entity";
+import { User } from "src/users/entities/user.entity";
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Reservation, ShowDetail, User])],
   providers: [ReservationsService],
-  controllers: [ReservationsController]
+  controllers: [ReservationsController],
 })
 export class ReservationsModule {}

--- a/src/reservations/reservations.service.spec.ts
+++ b/src/reservations/reservations.service.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ReservationsService } from './reservations.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { ReservationsService } from "./reservations.service";
 
-describe('ReservationsService', () => {
+describe("ReservationsService", () => {
   let service: ReservationsService;
 
   beforeEach(async () => {
@@ -12,7 +12,7 @@ describe('ReservationsService', () => {
     service = module.get<ReservationsService>(ReservationsService);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
   });
 });

--- a/src/reservations/reservations.service.ts
+++ b/src/reservations/reservations.service.ts
@@ -1,4 +1,71 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { User } from "src/users/entities/user.entity";
+import { Repository } from "typeorm";
+import { Reservation } from "./entities/reservation.entity";
+import { ShowDetail } from "src/shows/entities/show-detail.entity";
+import _ from "lodash";
 
 @Injectable()
-export class ReservationsService {}
+export class ReservationsService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    @InjectRepository(Reservation)
+    private readonly reservationsRepository: Repository<Reservation>,
+    @InjectRepository(ShowDetail)
+    private readonly showDetailsRepository: Repository<ShowDetail>,
+  ) {}
+
+  async createReservation(showDetailId: number, userId: number) {
+    // showDetailId에 해당되는 공연이 있는지, restOfSeat가 있는지 확인
+    const showDetail = await this.showDetailsRepository.findOne({
+      where: { id: showDetailId },
+      relations: ["show"],
+    });
+    if (_.isNil(showDetail)) {
+      throw new NotFoundException("해당 공연이 존재하지 않습니다.");
+    }
+    if (showDetail.reservatedSeat >= showDetail.seat) {
+      throw new NotFoundException("예매 가능한 좌석이 남아있지 않습니다.");
+    }
+
+    // userId에 해당되는 사용자의 price가 show의 가격보다 충분한지
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    const { price } = showDetail.show;
+    if (_.isNil(user)) {
+      throw new NotFoundException("해당 사용자가 존재하지 않습니다.");
+    }
+    if (user.point < price) {
+      throw new NotFoundException("사용자의 금액이 부족합니다.");
+    }
+
+    // ---- 트랜잭션 걸어야 되는 부분 ----
+    const reservation = this.reservationsRepository.create({ showDetail, user });
+    // 예매 생성
+    await this.reservationsRepository.save(reservation);
+
+    // 예매 완료시 사용자의 point - price
+    await this.usersRepository.update(
+      { id: userId },
+      { point: user.point - price },
+    );
+
+    // 예매 완료시 showDetail의 reservatedSeat +1
+    await this.showDetailsRepository.update(
+      { id: showDetailId },
+      { reservatedSeat: showDetail.reservatedSeat + 1 },
+    );
+    // ---- 트랜잭션 걸어야 되는 부분 ----
+
+    return reservation;
+  }
+
+  async getReservations(userId: number) {
+    if (_.isNil(userId)) {
+      throw new NotFoundException("사용자 아이디가 존재하지 않습니다.");
+    }
+    const reservations = await this.reservationsRepository.find({ where: { user: { id: userId } }, relations: ["showDetail"] });
+    return reservations;
+  }
+}

--- a/src/reservations/types/reservation-status.type.ts
+++ b/src/reservations/types/reservation-status.type.ts
@@ -1,0 +1,5 @@
+export enum RESERVATION_STATUS {
+  RESERVED = "reserved", // 예매 (결제 됨)
+  CANCELLED = "cancelled", // 취소
+  COMPLETED = "completed", // 끝 (공연 종료)
+}

--- a/src/shows/entities/show-detail.entity.ts
+++ b/src/shows/entities/show-detail.entity.ts
@@ -4,10 +4,12 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { Show } from "./show.entity";
 import _ from "lodash";
+import { Reservation } from "src/reservations/entities/reservation.entity";
 
 @Entity({
   name: "show_details",
@@ -16,25 +18,24 @@ export class ShowDetail {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Show, (show) => show.showDetails)
-  @JoinColumn({ name: "show_id" })
-  showId: number;
-
   @Column({ type: "datetime", nullable: false })
   showDate: Date;
 
   @Column({ type: "int", nullable: false })
   seat: number;
 
-  // 남은 좌석 수
-  @Column({ type: "int", nullable: false })
-  restOfSeat: number;
+  // 예매된 좌석 수
+  @Column({ type: "int", nullable: false, default: 0 })
+  reservatedSeat: number;
 
-  // restOfSeat = seat - 예매된 좌석
-  @BeforeInsert()
-  setRestOfSeat() {
-    if (_.isNil(this.restOfSeat)) {
-      this.restOfSeat = this.seat;
-    }
-  }
+  // showId를 show로 변경
+  @ManyToOne((type) => Show, (show) => show.showDetails)
+  @JoinColumn({ name: "show_id", referencedColumnName: "id" })
+  show: Show;
+
+  @Column({ type: "int", name: "show_id" })
+  show_id: number;
+
+  @OneToMany(() => Reservation, (reservation) => reservation.showDetail)
+  reservations: Reservation[];
 }

--- a/src/shows/entities/show.entity.ts
+++ b/src/shows/entities/show.entity.ts
@@ -2,12 +2,15 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
+  ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
 import { SHOW_CATEGORY } from "../types/show-category.type";
 import { ShowDetail } from "./show-detail.entity";
+import { User } from "src/users/entities/user.entity";
 
 @Entity({
   name: "shows",
@@ -46,6 +49,13 @@ export class Show {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @OneToMany(() => ShowDetail, (showDetail) => showDetail.showId, { cascade: true })
+  @ManyToOne(() => User, (user) => user.shows)
+  @JoinColumn({ name: "user_id", referencedColumnName: "id" })
+  user: User;
+
+  @Column({ type: "int", name: "user_id" })
+  user_id: number;
+
+  @OneToMany(() => ShowDetail, (showDetail) => showDetail.show)
   showDetails: ShowDetail[];
 }

--- a/src/shows/shows.controller.ts
+++ b/src/shows/shows.controller.ts
@@ -17,13 +17,15 @@ import { ShowsService } from "./shows.service";
 import { CreateShowDto } from "./dto/create-show.dto";
 import { UpdateShowDto } from "./dto/update-show.dto";
 import { FindShowsQuery } from "./dto/find-shows-query.dto";
+import { UserInfo } from "src/utils/userInfo.decorator";
+import { User } from "src/users/entities/user.entity";
 
 @UseGuards(RolesGuard)
 @Controller("shows")
 export class ShowsController {
   constructor(private readonly showsService: ShowsService) {}
 
-  @Get("")
+  @Get()
   async findShows(@Query() query: FindShowsQuery) {
     return this.showsService.findShows(query);
   }
@@ -36,25 +38,39 @@ export class ShowsController {
 
   // keyword로 검색
   @Get("search/:keyword")
-  async findShowByKeyword(@Param("keyword") keyword: string) {
+  async findShowByKeyword(
+    @Param("keyword") keyword: string
+  ) {
     return this.showsService.findShowsByKeyword(keyword);
   }
 
   @Roles(ROLE.ADMIN)
   @Post()
-  async createShow(@Body() createShowDto: CreateShowDto) {
-    return this.showsService.createShow(createShowDto);
+  async createShow(
+    @UserInfo() user: User, 
+    @Body() createShowDto: CreateShowDto) {
+    const userId = +user.id;
+    return this.showsService.createShow(userId, createShowDto);
   }
 
   @Roles(ROLE.ADMIN)
   @Patch(":id")
-  async updateShow(@Param("id") showId: number, @Body() updateShowDto: UpdateShowDto) {
-    return this.showsService.updateShow(showId, updateShowDto);
+  async updateShow(
+    @UserInfo() user: User,
+    @Param("id") showId: number,
+    @Body() updateShowDto: UpdateShowDto
+  ) {
+    const userId = +user.id;
+    return this.showsService.updateShow(userId, showId, updateShowDto);
   }
 
   @Roles(ROLE.ADMIN)
   @Delete(":id")
-  async deleteShow(@Param("id") showId: number) {
-    return this.showsService.deleteShow(showId);
+  async deleteShow(
+    @UserInfo() user: User,
+    @Param("id") showId: number
+  ) {
+    const userId = +user.id;
+    return this.showsService.deleteShow(userId, showId);
   }
 }

--- a/src/shows/shows.service.ts
+++ b/src/shows/shows.service.ts
@@ -18,7 +18,7 @@ export class ShowsService {
     private readonly showDetailRepository: Repository<ShowDetail>,
   ) {}
 
-  async createShow(createShowDto: CreateShowDto) {
+  async createShow(userId: number,createShowDto: CreateShowDto) {
     const {
       title,
       description,
@@ -33,6 +33,7 @@ export class ShowsService {
     } = createShowDto;
 
     const show = await this.showRepository.save({
+      user_id: userId,
       title,
       description,
       img,
@@ -44,13 +45,13 @@ export class ShowsService {
     });
 
     for (const date of showDate) {
-      await this.showDetailRepository.save({ showId: show.id, showDate: date, seat });
+      await this.showDetailRepository.save({ show_id: show.id, showDate: date, seat });
     }
 
     return { message: "공연 등록에 성공하였습니다." };
   }
 
-  async updateShow(showId: number, updateShowDto: UpdateShowDto) {
+  async updateShow(userId: number, showId: number, updateShowDto: UpdateShowDto) {
     const {
       title,
       description,
@@ -81,7 +82,7 @@ export class ShowsService {
 
     // showId에 맞는 show있나 체크
     const show = await this.showRepository.findOne({
-      where: { id: showId },
+      where: { id: showId, user_id: userId },
       relations: { showDetails: true },
     });
     if (_.isEmpty(show)) {
@@ -100,18 +101,18 @@ export class ShowsService {
 
     // showDate값이 있나 체크. 있으면 다 날리고 다시 만들기?
     if (!_.isEmpty(showDate)) {
-      await this.showDetailRepository.delete({ showId: show.id });
+      await this.showDetailRepository.delete({ show: show });
 
       for (const date of showDate) {
-        await this.showDetailRepository.save({ showId: show.id, showDate: date, seat });
+        await this.showDetailRepository.save({ show_id: show.id, showDate: date, seat });
       }
     }
 
     return { message: "공연 수정에 성공하였습니다." };
   }
 
-  async deleteShow(showId: number) {
-    const show = await this.showRepository.findOne({ where: { id: showId } });
+  async deleteShow(userId: number, showId: number) {
+    const show = await this.showRepository.findOne({ where: { id: showId, user_id: userId } });
     if (!show) {
       throw new NotFoundException("공연을 찾을 수 없습니다.");
     }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -3,11 +3,14 @@ import {
   CreateDateColumn,
   Entity,
   Index,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
 
 import { ROLE } from "../types/user-role.type";
+import { Reservation } from "src/reservations/entities/reservation.entity";
+import { Show } from "src/shows/entities/show.entity";
 
 @Index("email", ["email"], { unique: true })
 @Entity({
@@ -37,4 +40,10 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @OneToMany(type => Show, (show) => show.user)
+  shows: Show[];
+
+  @OneToMany(type => Reservation, (reservation) => reservation.user)
+  reservations: Reservation[];
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -53,7 +53,7 @@ export class UsersService {
       throw new UnauthorizedException("비밀번호를 확인해주세요.");
     }
 
-    const payload = { email, sub: user.id, role: user.role };
+    const payload = { email, id: user.id, role: user.role };
     return {
       access_token: this.jwtService.sign(payload),
     };


### PR DESCRIPTION
1. 예매하기 API POST /reservations
 
- [x] 잔여 좌석 수 체크 / 잔액 체크 / 좌석 수 -1 / 잔액 -price 
- [ ] 프론트가 보기 쉽게, 쓰기 편하게 + 불필요한 중복된 정보 없게 responce형태 바꾸기
- [ ] 트랜잭션

2. 예매 기록 조회 API GET /reservations
- [x] shows테이블에서 정보도 가져와야 된다. title / description
- [ ] 프론트가 보기 쉽게, 쓰기 편하게 + 불필요한 중복된 정보 없게 responce형태 바꾸기


 